### PR TITLE
Add dataverse and xml schema health checks

### DIFF
--- a/src/main/assembly/dist/cfg/config.yml
+++ b/src/main/assembly/dist/cfg/config.yml
@@ -60,3 +60,32 @@ validation:
       - "http://www.tapr.org/ohl.html"
       - "http://dans.knaw.nl/en/about/organisation-and-policy/legal-information/DANSGeneralconditionsofuseUKDEF.pdf"
       - "http://dans.knaw.nl/en/about/organisation-and-policy/legal-information/DANSLicence.pdf"
+
+health:
+  delayedShutdownHandlerEnabled: false
+  healthChecks:
+    - name: deadlocks
+      critical: true
+      schedule:
+        checkInterval: 5s
+        downtimeInterval: 10s
+        failureAttempts: 1
+        successAttempts: 1
+    - name: xml-schemas
+      critical: true
+      initialState: false
+      schedule:
+        checkInterval: 60s
+        initialDelay: 1s
+        downtimeInterval: 30s
+        failureAttempts: 1
+        successAttempts: 1
+    - name: dataverse
+      critical: false
+      initialState: true
+      schedule:
+        checkInterval: 10s
+        initialDelay: 1s
+        downtimeInterval: 5s
+        failureAttempts: 2
+        successAttempts: 3

--- a/src/main/java/nl/knaw/dans/validatedansbag/DdValidateDansBagApplication.java
+++ b/src/main/java/nl/knaw/dans/validatedansbag/DdValidateDansBagApplication.java
@@ -21,6 +21,8 @@ import io.dropwizard.forms.MultiPartBundle;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import nl.knaw.dans.validatedansbag.core.engine.RuleEngineImpl;
+import nl.knaw.dans.validatedansbag.core.health.DataverseHealthCheck;
+import nl.knaw.dans.validatedansbag.core.health.XmlSchemaHealthCheck;
 import nl.knaw.dans.validatedansbag.core.rules.BagRulesImpl;
 import nl.knaw.dans.validatedansbag.core.rules.DatastationRulesImpl;
 import nl.knaw.dans.validatedansbag.core.rules.FilesXmlRulesImpl;
@@ -93,5 +95,8 @@ public class DdValidateDansBagApplication extends Application<DdValidateDansBagC
         environment.jersey().register(new IllegalArgumentExceptionMapper());
         environment.jersey().register(new ValidateResource(ruleEngineService, fileService));
         environment.jersey().register(new ValidateOkDtoYamlMessageBodyWriter());
+
+        environment.healthChecks().register("xml-schemas", new XmlSchemaHealthCheck(xmlSchemaValidator));
+        environment.healthChecks().register("dataverse", new DataverseHealthCheck(dataverseService));
     }
 }

--- a/src/main/java/nl/knaw/dans/validatedansbag/core/health/DataverseHealthCheck.java
+++ b/src/main/java/nl/knaw/dans/validatedansbag/core/health/DataverseHealthCheck.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2022 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.validatedansbag.core.health;
+
+import com.codahale.metrics.health.HealthCheck;
+import nl.knaw.dans.lib.dataverse.DataverseException;
+import nl.knaw.dans.validatedansbag.core.service.DataverseService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+public class DataverseHealthCheck extends HealthCheck {
+    private static final Logger log = LoggerFactory.getLogger(DataverseHealthCheck.class);
+
+    private final DataverseService dataverseService;
+
+    public DataverseHealthCheck(DataverseService dataverseService) {
+        this.dataverseService = dataverseService;
+    }
+
+    @Override
+    protected Result check() {
+        try {
+            dataverseService.checkConnection();
+            return Result.healthy();
+        }
+        catch (IOException | DataverseException e) {
+            return Result.builder()
+                .withMessage(e.getMessage())
+                .unhealthy(e)
+                .build();
+        }
+    }
+}

--- a/src/main/java/nl/knaw/dans/validatedansbag/core/health/XmlSchemaHealthCheck.java
+++ b/src/main/java/nl/knaw/dans/validatedansbag/core/health/XmlSchemaHealthCheck.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2022 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.validatedansbag.core.health;
+
+import com.codahale.metrics.health.HealthCheck;
+import nl.knaw.dans.validatedansbag.core.service.XmlSchemaValidator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class XmlSchemaHealthCheck extends HealthCheck {
+    private static final Logger log = LoggerFactory.getLogger(XmlSchemaHealthCheck.class);
+    private final XmlSchemaValidator xmlSchemaValidator;
+
+    public XmlSchemaHealthCheck(XmlSchemaValidator xmlSchemaValidator) {
+        this.xmlSchemaValidator = xmlSchemaValidator;
+    }
+
+    @Override
+    protected Result check() throws Exception {
+        try {
+            log.trace("Loading schema's if necessary");
+            xmlSchemaValidator.loadSchemas();
+            return Result.healthy();
+        }
+        catch (Throwable e) {
+            log.error("Unable to load schema's", e);
+            return Result.unhealthy(e);
+        }
+    }
+}

--- a/src/main/java/nl/knaw/dans/validatedansbag/core/service/DataverseService.java
+++ b/src/main/java/nl/knaw/dans/validatedansbag/core/service/DataverseService.java
@@ -35,4 +35,6 @@ public interface DataverseService {
     DataverseResponse<DatasetLatestVersion> getDataset(String globalId) throws IOException, DataverseException;
 
     DataverseResponse<List<RoleAssignmentReadOnly>> getDataverseRoleAssignments(String itemId) throws IOException, DataverseException;
+
+    void checkConnection() throws IOException, DataverseException;
 }

--- a/src/main/java/nl/knaw/dans/validatedansbag/core/service/DataverseServiceImpl.java
+++ b/src/main/java/nl/knaw/dans/validatedansbag/core/service/DataverseServiceImpl.java
@@ -83,7 +83,6 @@ public class DataverseServiceImpl implements DataverseService {
     @Override
     public DataverseResponse<DatasetLatestVersion> getDataset(String globalId) throws IOException, DataverseException {
         var client = this.getDataverseClient();
-
         log.trace("Getting dataset from dataverse with id {}", globalId);
         return client.dataset(globalId).getLatestVersion();
     }
@@ -93,5 +92,12 @@ public class DataverseServiceImpl implements DataverseService {
         var client = this.getDataverseClient();
         log.trace("Getting dataset role assignments from dataverse for dataset with id {}", itemId);
         return client.dataverse("root").listRoleAssignments();
+    }
+
+    @Override
+    public void checkConnection() throws IOException, DataverseException {
+        var client = this.getDataverseClient();
+        log.trace("Checking dataverse connection");
+        client.checkConnection();
     }
 }

--- a/src/main/java/nl/knaw/dans/validatedansbag/core/service/XmlSchemaValidator.java
+++ b/src/main/java/nl/knaw/dans/validatedansbag/core/service/XmlSchemaValidator.java
@@ -25,4 +25,6 @@ import java.util.List;
 public interface XmlSchemaValidator {
 
     List<SAXParseException> validateDocument(Node node, String schema) throws IOException, SAXException;
+
+    void loadSchemas() throws Exception;
 }

--- a/src/test/resources/debug-etc/config.yml
+++ b/src/test/resources/debug-etc/config.yml
@@ -69,3 +69,32 @@ validation:
       - "http://www.tapr.org/ohl.html"
       - "http://dans.knaw.nl/en/about/organisation-and-policy/legal-information/DANSGeneralconditionsofuseUKDEF.pdf"
       - "http://dans.knaw.nl/en/about/organisation-and-policy/legal-information/DANSLicence.pdf"
+
+health:
+  delayedShutdownHandlerEnabled: false
+  healthChecks:
+    - name: deadlocks
+      critical: true
+      schedule:
+        checkInterval: 5s
+        downtimeInterval: 10s
+        failureAttempts: 1
+        successAttempts: 1
+    - name: xml-schemas
+      critical: true
+      initialState: false
+      schedule:
+        checkInterval: 60s
+        initialDelay: 1s
+        downtimeInterval: 30s
+        failureAttempts: 1
+        successAttempts: 1
+    - name: dataverse
+      critical: false
+      initialState: true
+      schedule:
+        checkInterval: 10s
+        initialDelay: 1s
+        downtimeInterval: 5s
+        failureAttempts: 2
+        successAttempts: 3


### PR DESCRIPTION
Fixes DD-1137

# Description of changes
Adds health checks for dataverse and xml schema's, plus default configuration for the health manager

# How to test


# Related PRs
(Add links)
*

# Notify
@DANS-KNAW/dataversedans
