### PR TITLE
DD-1174: Exactly one license provided

### DIFF
--- a/src/main/java/nl/knaw/dans/validatedansbag/core/rules/BagRules.java
+++ b/src/main/java/nl/knaw/dans/validatedansbag/core/rules/BagRules.java
@@ -43,7 +43,7 @@ public interface BagRules {
 
     BagValidatorRule isOriginalFilepathsFileComplete();
 
-    BagValidatorRule ddmMayContainDctermsLicenseFromList();
+    BagValidatorRule ddmMustContainOneDctermsLicenseFromList();
 
     BagValidatorRule ddmDoiIdentifiersAreValid();
 

--- a/src/main/java/nl/knaw/dans/validatedansbag/core/rules/BagRulesImpl.java
+++ b/src/main/java/nl/knaw/dans/validatedansbag/core/rules/BagRulesImpl.java
@@ -427,7 +427,7 @@ public class BagRulesImpl implements BagRules {
     }
 
     @Override
-    public BagValidatorRule ddmMayContainDctermsLicenseFromList() {
+    public BagValidatorRule ddmMustContainOneDctermsLicenseFromList() {
         return (path) -> {
             var document = xmlReader.readXmlFile(path.resolve("metadata/dataset.xml"));
             var expr = "//ddm:dcmiMetadata/dcterms:license[@xsi:type]";

--- a/src/main/java/nl/knaw/dans/validatedansbag/core/service/RuleEngineServiceImpl.java
+++ b/src/main/java/nl/knaw/dans/validatedansbag/core/service/RuleEngineServiceImpl.java
@@ -100,7 +100,7 @@ public class RuleEngineServiceImpl implements RuleEngineService {
 
             // metadata/dataset.xml
             new NumberedRule("3.1.1", xmlRules.xmlFileConformsToSchema(datasetPath, "dataset.xml"), List.of("1.1.1", "2.2(a)")),
-            new NumberedRule("3.1.2", bagRules.ddmMayContainDctermsLicenseFromList(), List.of("3.1.1")),
+            new NumberedRule("3.1.2", bagRules.ddmMustContainOneDctermsLicenseFromList(), List.of("3.1.1")),
             new NumberedRule("3.1.3", bagRules.ddmDoiIdentifiersAreValid(), List.of("3.1.1")),
 
             new NumberedRule("3.1.4(a)", bagRules.ddmDaisAreValid(), List.of("3.1.1")),
@@ -138,6 +138,7 @@ public class RuleEngineServiceImpl implements RuleEngineService {
             new NumberedRule("4.4(a)", datastationRules.bagExistsInDatastation(), ValidationContext.WITH_DATA_STATION_CONTEXT, List.of("4.1")),
             new NumberedRule("4.4(b)", datastationRules.organizationalIdentifierExistsInDataset(), ValidationContext.WITH_DATA_STATION_CONTEXT, List.of("4.1", "4.4(a)")),
             new NumberedRule("4.4(c)", datastationRules.userIsAuthorizedToUpdateDataset(), ValidationContext.WITH_DATA_STATION_CONTEXT, List.of("4.1", "4.4(a)")),
+            //NumberedRule 4.5 is checked in the implementation of NumberedRule 3.1.2
             new NumberedRule("4.6", datastationRules.embargoPeriodWithinLimits(), ValidationContext.WITH_DATA_STATION_CONTEXT),
         };
 

--- a/src/test/java/nl/knaw/dans/validatedansbag/core/rules/BagRulesImplTest.java
+++ b/src/test/java/nl/knaw/dans/validatedansbag/core/rules/BagRulesImplTest.java
@@ -493,7 +493,7 @@ class BagRulesImplTest {
 
         var checker = getBagRulesWithXmlReader(reader);
 
-        var result = checker.ddmMayContainDctermsLicenseFromList().validate(Path.of("bagdir"));
+        var result = checker.ddmMustContainOneDctermsLicenseFromList().validate(Path.of("bagdir"));
         assertEquals(RuleResult.Status.ERROR, result.getStatus());
     }
     @Test


### PR DESCRIPTION
Fixes DD-1174

# Description of changes
* Check that exactly one license is provided from the list of allowed licenses

# How to test


# Related PRs
(Add links)
*

# Notify
@DANS-KNAW/dataversedans
