### PR TITLE
DD-1231 Explicit version voor maven-release-plugin

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -53,13 +53,6 @@
 
     <build>
         <plugins>
-<!--            <plugin>-->
-<!--                <groupId>org.apache.maven.plugins</groupId>-->
-<!--                <artifactId>maven-javadoc-plugin</artifactId>-->
-<!--                <configuration>-->
-<!--                    <skip>true</skip>-->
-<!--                </configuration>-->
-<!--            </plugin>-->
             <plugin>
                 <groupId>org.openapitools</groupId>
                 <artifactId>openapi-generator-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
+                <version>3.0.0-M6</version>
                 <configuration>
                     <tagNameFormat>v@{project.version}</tagNameFormat>
                     <autoVersionSubmodules>true</autoVersionSubmodules>


### PR DESCRIPTION
Fixes DD-1231

# Description of changes
* Use version 3 of plugin to avoid inheriting the Javadoc plugin from v2.5.3
* Remove the - now unnecessary - skipping of Javadoc

# Notify
@DANS-KNAW/dataversedans
