### PR TITLE
DD-1375 Implemented new version of 5.2. rule

### DIFF
--- a/application/src/main/java/nl/knaw/dans/validatedansbag/core/rules/RuleSets.java
+++ b/application/src/main/java/nl/knaw/dans/validatedansbag/core/rules/RuleSets.java
@@ -194,7 +194,8 @@ public class RuleSets {
         // 5 Vault as a Service context requirements
         return List.of(
                 // TODO: 5.1
-                new NumberedRule("5.2", new DatasetXmlDoisAreValid(xmlReader), List.of("3.1.1"))
+                new NumberedRule("5.2(a)", new DatasetXmlContainsAtMostOneIdentifierWithIdTypeDoi(xmlReader), List.of("3.1.1")),
+                new NumberedRule("5.2(b)", new DatasetXmlDoisAreValid(xmlReader), List.of("5.2(a)"))
         );
     }
 

--- a/application/src/test/java/nl/knaw/dans/validatedansbag/core/rules/DatasetXmlContainsAtMostOneIdentifierWithIdTypeDoiTest.java
+++ b/application/src/test/java/nl/knaw/dans/validatedansbag/core/rules/DatasetXmlContainsAtMostOneIdentifierWithIdTypeDoiTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2022 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.validatedansbag.core.rules;
+
+import nl.knaw.dans.validatedansbag.core.engine.RuleResult;
+import nl.knaw.dans.validatedansbag.core.service.XmlReaderImpl;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class DatasetXmlContainsAtMostOneIdentifierWithIdTypeDoiTest extends RuleTestFixture {
+
+    @Test
+    void should_return_SKIP_DEPENDENCIES_when_no_dois_present() throws Exception {
+        final String xml = "<ddm:DDM\n"
+            + "        xmlns:dc=\"http://purl.org/dc/elements/1.1/\"\n"
+            + "        xmlns:dcx-dai=\"http://easy.dans.knaw.nl/schemas/dcx/dai/\"\n"
+            + "        xmlns:ddm=\"http://schemas.dans.knaw.nl/dataset/ddm-v2/\"\n"
+            + "        xmlns:dcterms=\"http://purl.org/dc/terms/\"\n"
+            + "        xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
+            + "        xmlns:id-type=\"http://easy.dans.knaw.nl/schemas/vocab/identifier-type/\">\n"
+            + "    <ddm:dcmiMetadata>\n"
+            + "    </ddm:dcmiMetadata>\n"
+            + "</ddm:DDM>";
+
+        var document = parseXmlString(xml);
+        var reader = Mockito.spy(new XmlReaderImpl());
+
+        Mockito.doReturn(document).when(reader).readXmlFile(Mockito.any());
+
+        var result = new DatasetXmlContainsAtMostOneIdentifierWithIdTypeDoi(reader).validate(Path.of("bagdir"));
+        assertEquals(RuleResult.Status.SKIP_DEPENDENCIES, result.getStatus());
+    }
+
+    @Test
+    void should_return_SUCCESS_when_one_dois_present() throws Exception {
+        final String xml = "<ddm:DDM\n"
+            + "        xmlns:dc=\"http://purl.org/dc/elements/1.1/\"\n"
+            + "        xmlns:dcx-dai=\"http://easy.dans.knaw.nl/schemas/dcx/dai/\"\n"
+            + "        xmlns:ddm=\"http://schemas.dans.knaw.nl/dataset/ddm-v2/\"\n"
+            + "        xmlns:dcterms=\"http://purl.org/dc/terms/\"\n"
+            + "        xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
+            + "        xmlns:id-type=\"http://easy.dans.knaw.nl/schemas/vocab/identifier-type/\">\n"
+            + "    <ddm:dcmiMetadata>\n"
+            + "        <dcterms:identifier xsi:type=\"id-type:DOI\">10.1234/fantasy-doi-id</dcterms:identifier>\n"
+            + "    </ddm:dcmiMetadata>\n"
+            + "</ddm:DDM>";
+
+        var document = parseXmlString(xml);
+        var reader = Mockito.spy(new XmlReaderImpl());
+
+        Mockito.doReturn(document).when(reader).readXmlFile(Mockito.any());
+
+        var result = new DatasetXmlContainsAtMostOneIdentifierWithIdTypeDoi(reader).validate(Path.of("bagdir"));
+        assertEquals(RuleResult.Status.SUCCESS, result.getStatus());
+    }
+
+    @Test
+    void should_return_ERROR_when_two_dois_present() throws Exception {
+        final String xml = "<ddm:DDM\n"
+            + "        xmlns:dc=\"http://purl.org/dc/elements/1.1/\"\n"
+            + "        xmlns:dcx-dai=\"http://easy.dans.knaw.nl/schemas/dcx/dai/\"\n"
+            + "        xmlns:ddm=\"http://schemas.dans.knaw.nl/dataset/ddm-v2/\"\n"
+            + "        xmlns:dcterms=\"http://purl.org/dc/terms/\"\n"
+            + "        xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
+            + "        xmlns:id-type=\"http://easy.dans.knaw.nl/schemas/vocab/identifier-type/\">\n"
+            + "    <ddm:dcmiMetadata>\n"
+            + "        <dcterms:identifier xsi:type=\"id-type:DOI\">10.1234/fantasy-doi-id</dcterms:identifier>\n"
+            + "        <dcterms:identifier xsi:type=\"id-type:DOI\">10.1234/fantasy-doi-id2</dcterms:identifier>\n"
+            + "    </ddm:dcmiMetadata>\n"
+            + "</ddm:DDM>";
+
+        var document = parseXmlString(xml);
+        var reader = Mockito.spy(new XmlReaderImpl());
+
+        Mockito.doReturn(document).when(reader).readXmlFile(Mockito.any());
+
+        var result = new DatasetXmlContainsAtMostOneIdentifierWithIdTypeDoi(reader).validate(Path.of("bagdir"));
+        assertEquals(RuleResult.Status.ERROR, result.getStatus());
+    }
+}


### PR DESCRIPTION
Fixes DD-1375

# Description of changes
At most one DOI is now allowed and if it is present it is checked for syntax. I have merged the corresponding changes to the BagIt Profile doc directly to blessed/master. See: https://dans-knaw.github.io/dans-bagit-profile/versions/1.0.0/#5-vault-as-a-service-context-requirements

# Notify

@DANS-KNAW/dataversedans
