### PR TITLE
Fix rule 4.2. Only accept exact matches for licenses

### DIFF
--- a/src/main/java/nl/knaw/dans/validatedansbag/core/validator/LicenseValidatorImpl.java
+++ b/src/main/java/nl/knaw/dans/validatedansbag/core/validator/LicenseValidatorImpl.java
@@ -50,23 +50,12 @@ public class LicenseValidatorImpl implements LicenseValidator {
 
     @Override
     public boolean isValidLicense(String license) throws IOException, DataverseException {
-        // strip trailing slashes so urls are more consistent
-        // it might be worth investigating if this should be more extensive
-        // for example, also dropping the www. prefix
         var licenses = dataverseService.getLicenses().stream()
             .filter(License::isActive)
             .map(License::getUri)
             .filter(Objects::nonNull)
-            .map(this::normalizeLicense)
             .collect(Collectors.toSet());
 
-        var normalizedLicense = normalizeLicense(license);
-        log.trace("Normalized license from {} to {}", license, normalizedLicense);
-
-        return licenses.contains(normalizedLicense);
-    }
-
-    String normalizeLicense(String license) {
-        return license.replaceAll("/+$", "");
+        return licenses.contains(license);
     }
 }

--- a/src/test/java/nl/knaw/dans/validatedansbag/core/validator/LicenseValidatorImplTest.java
+++ b/src/test/java/nl/knaw/dans/validatedansbag/core/validator/LicenseValidatorImplTest.java
@@ -50,7 +50,7 @@ class LicenseValidatorImplTest {
 
     @Test
     void isValidLicense_should_return_true_for_valid_uri() throws Exception {
-        var license = "http://dans.nl/";
+        var license = "http://dans.nl";
         var dvLicense = new License();
         dvLicense.setActive(true);
         dvLicense.setUri("http://dans.nl");
@@ -63,7 +63,7 @@ class LicenseValidatorImplTest {
 
     @Test
     void isValidLicense_should_return_false_for_invalid_uri() throws Exception {
-        var license = "http://dans.nl/";
+        var license = "http://dans.nl";
         var dvLicense = new License();
         dvLicense.setActive(true);
         dvLicense.setUri("http://something.else.com");


### PR DESCRIPTION
NO JIRA

# Description of changes
Rule 4.2 from DANS BagIt Profile states that the license URI provided in dataset.xml must be an exact match. The code still contained a function to strip the last slash, thereby letting through licenses that later were rejected by Dataverse. Removed this `normalize` step.

See:
* https://dans-knaw.github.io/dans-bagit-profile/versions/1.0.0/#4-data-station-context-requirements
* https://dans-knaw.github.io/dd-dans-sword2-examples/migrating-from-easy/#exactly-one-license-element-with-xsitypedctermsuri

# How to test
Before and after the change run a https://github.com/DANS-KNAW/dd-dans-sword2-examples with the license URI changed to a valid one **except for an added end slash**. You will need to update the tagmanifest entry for dataset.xml after changing it.


# Notify

@DANS-KNAW/dataversedans
