### PR TITLE
DD-1458 Fix Uncontrolled data used in path expression - part 1

### DIFF
--- a/src/main/assembly/dist/cfg/config.yml
+++ b/src/main/assembly/dist/cfg/config.yml
@@ -33,6 +33,7 @@ vaultCatalog:
 #  baseUrl: null
 
 validation:
+  baseFolder: "/var/opt/dans.knaw.nl/tmp/"
   otherIdPrefixes: []
 
   xmlSchemas:

--- a/src/main/java/nl/knaw/dans/validatedansbag/core/config/ValidationConfig.java
+++ b/src/main/java/nl/knaw/dans/validatedansbag/core/config/ValidationConfig.java
@@ -21,12 +21,17 @@ import lombok.Setter;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+import java.nio.file.Path;
 import java.util.List;
 
 @Valid
 @Getter
 @Setter
 public class ValidationConfig {
+
+    @NotNull
+    @Valid
+    Path baseFolder;
 
     @NotNull
     @Valid

--- a/src/test/resources/debug-etc/config.yml
+++ b/src/test/resources/debug-etc/config.yml
@@ -34,6 +34,7 @@ dataverse:
 
 
 validation:
+  baseFolder: "/var/opt/dans.knaw.nl/tmp/"
   otherIdPrefixes:
     - 'EXAMPLE:'
     - 'USER01:'


### PR DESCRIPTION
Fixes DD-1458 Fix Uncontrolled data used in path expression

# Description of changes
  - add a  new attribute to validation called: baseFolder. This should be the only accessible folder for this service. 
# How to test

# Related PRs

(Add links)

*

# Notify

@DANS-KNAW/core-systems
