### PR TITLE
DD-1458 Fix Uncontrolled data used in path expression - Part-2 A

### DIFF
--- a/src/main/java/nl/knaw/dans/validatedansbag/core/service/FileServiceImpl.java
+++ b/src/main/java/nl/knaw/dans/validatedansbag/core/service/FileServiceImpl.java
@@ -39,11 +39,13 @@ public class FileServiceImpl implements FileService {
 
     @Override
     public boolean isDirectory(Path path) {
+        checkBaseFolderSecurity(path);
         return Files.exists(path) && Files.isDirectory(path);
     }
 
     @Override
     public boolean isFile(Path path) {
+        checkBaseFolderSecurity(path);
         return Files.exists(path) && Files.isRegularFile(path);
     }
 
@@ -95,6 +97,7 @@ public class FileServiceImpl implements FileService {
 
             while (entry != null) {
                 var targetPath = tempPath.resolve(entry.getName());
+                checkBaseFolderSecurity(targetPath);
 
                 if (entry.isDirectory()) {
                     Files.createDirectories(targetPath);

--- a/src/main/java/nl/knaw/dans/validatedansbag/core/service/FileServiceImpl.java
+++ b/src/main/java/nl/knaw/dans/validatedansbag/core/service/FileServiceImpl.java
@@ -73,11 +73,13 @@ public class FileServiceImpl implements FileService {
 
     @Override
     public boolean exists(Path path) {
+        checkBaseFolderSecurity(path);
         return Files.exists(path);
     }
 
     @Override
     public boolean isReadable(Path path) {
+        checkBaseFolderSecurity(path);
         return Files.exists(path) && Files.isReadable(path);
     }
 

--- a/src/main/java/nl/knaw/dans/validatedansbag/core/service/FileServiceImpl.java
+++ b/src/main/java/nl/knaw/dans/validatedansbag/core/service/FileServiceImpl.java
@@ -96,7 +96,7 @@ public class FileServiceImpl implements FileService {
             var entry = input.getNextEntry();
 
             while (entry != null) {
-                var targetPath = tempPath.resolve(entry.getName());
+                var targetPath = tempPath.resolve(entry.getName()).normalize().toAbsolutePath();
                 checkBaseFolderSecurity(targetPath);
 
                 if (entry.isDirectory()) {

--- a/src/main/java/nl/knaw/dans/validatedansbag/resources/ValidateResource.java
+++ b/src/main/java/nl/knaw/dans/validatedansbag/resources/ValidateResource.java
@@ -61,12 +61,12 @@ public class ValidateResource {
         @Valid @NotNull @FormDataParam(value = "command") ValidateCommandDto command,
         @FormDataParam(value = "zip") InputStream zipInputStream
     ) {
-        var location = command.getBagLocation();
-        var depositType = toDepositType(command.getPackageType());
-
         log.info("Received request to validate bag: {}", command);
 
         try {
+            var location = command.getBagLocation();
+            var depositType = toDepositType(command.getPackageType());
+
             ValidateOkDto validateResult;
 
             if (location == null) {


### PR DESCRIPTION
Fixes DD-1458 Fix Uncontrolled data used in path expression

# Description of changes
  - Added a **base-folder** to the `config.yml` file to check it as a trusted base folder where deposited datasets must be a child of this base folder. 
  - Also `tmp` folder to unzip, zipped files should be a sub-folder of this base-folder.
  - Unit-tests: base-folder is in general: `/home/project-dir/target/test-cases`

# How to test
  - Starting vagrant
    - `start-preprovisioned-box.py -s dev_archaeology`
    - `deploy.py -m dd-validate-dans-bag dev_archaeology`
    - or to follow the deposits: `deploy.py  -m dd-validate-dans-bag -m dd-manage-deposit dev_archaeology`
  
  - Deposit vaild/invalid datasets using
    - cd to local folder: `~/git/dans-core-systems/modules/dd-dans-sword2-examples` 
    - run examples: 
      - `./run-simple-deposit.sh https://dev.sword2.archaeology.datastations.nl/collection/1 user001 user001 src/main/resources/example-bags/valid/audiences`
      - `./run-validation.sh https://dev.sword2.archaeology.datastations.nl/validate-dans-bag src/main/resources/example-bags/valid/audiences-sha256`
      - `./run-validation.sh https://dev.sword2.archaeology.datastations.nl/validate-dans-bag src/main/resources/example-bags/invalid/invalid-license`
      - `./run-continued-deposit.sh https://dev.sword2.archaeology.datastations.nl/collection/1 user001 user001 200000 src/main/resources/example-bags/valid/audiences-sha256`
  
  - Looking at the results:
    - Reports:
      - in the terminal: `curl 'accept: text/csv' http://dev.sword2.archaeology.datastations.nl:20355/report`  
      - in the firefox browser: `http://dev.sword2.archaeology.datastations.nl:20355/report

# Related PRs

(Add links)

*

# Notify

@DANS-KNAW/core-systems
