### PR TITLE
DD-1458 Fix uncontrolled data used in path expression - Test 1: rever…

### DIFF
--- a/src/main/java/nl/knaw/dans/validatedansbag/core/rules/OptionalBagFileIsUtf8Decodable.java
+++ b/src/main/java/nl/knaw/dans/validatedansbag/core/rules/OptionalBagFileIsUtf8Decodable.java
@@ -34,8 +34,6 @@ public class OptionalBagFileIsUtf8Decodable implements BagValidatorRule {
     public RuleResult validate(Path path) throws Exception {
         try {
             var target = path.resolve(filename);
-            //fileService.checkBaseFolderSecurity(target);
-
             if (fileService.exists(target)) {
                 fileService.readFileContents(target, StandardCharsets.UTF_8);
                 return RuleResult.ok();

--- a/src/main/java/nl/knaw/dans/validatedansbag/core/rules/OptionalBagFileIsUtf8Decodable.java
+++ b/src/main/java/nl/knaw/dans/validatedansbag/core/rules/OptionalBagFileIsUtf8Decodable.java
@@ -34,7 +34,7 @@ public class OptionalBagFileIsUtf8Decodable implements BagValidatorRule {
     public RuleResult validate(Path path) throws Exception {
         try {
             var target = path.resolve(filename);
-            fileService.checkBaseFolderSecurity(target);
+            //fileService.checkBaseFolderSecurity(target);
 
             if (fileService.exists(target)) {
                 fileService.readFileContents(target, StandardCharsets.UTF_8);

--- a/src/main/java/nl/knaw/dans/validatedansbag/core/service/FileService.java
+++ b/src/main/java/nl/knaw/dans/validatedansbag/core/service/FileService.java
@@ -46,6 +46,5 @@ public interface FileService {
 
     Optional<Path> getFirstDirectory(Path path) throws IOException;
 
-    //void checkBaseFolderSecurity(Path path) throws RuntimeException;
     Path getSecurePath(Path path) throws RuntimeException;
 }

--- a/src/main/java/nl/knaw/dans/validatedansbag/core/service/FileService.java
+++ b/src/main/java/nl/knaw/dans/validatedansbag/core/service/FileService.java
@@ -46,5 +46,6 @@ public interface FileService {
 
     Optional<Path> getFirstDirectory(Path path) throws IOException;
 
-    void checkBaseFolderSecurity(Path path) throws RuntimeException;
+    //void checkBaseFolderSecurity(Path path) throws RuntimeException;
+    Path getSecurePath(Path path) throws RuntimeException;
 }

--- a/src/main/java/nl/knaw/dans/validatedansbag/core/service/FileServiceImpl.java
+++ b/src/main/java/nl/knaw/dans/validatedansbag/core/service/FileServiceImpl.java
@@ -95,12 +95,13 @@ public class FileServiceImpl implements FileService {
 
             while (entry != null) {
                 var targetPath = tempPath.resolve(entry.getName());
+                Path securePath = getSecurePath(targetPath);
 
                 if (entry.isDirectory()) {
-                    Files.createDirectories(targetPath);
+                    Files.createDirectories(securePath);
                 }
                 else {
-                    writeStreamToFile(input, targetPath);
+                    writeStreamToFile(input, securePath);
                 }
 
                 entry = input.getNextEntry();

--- a/src/main/java/nl/knaw/dans/validatedansbag/core/service/FileServiceImpl.java
+++ b/src/main/java/nl/knaw/dans/validatedansbag/core/service/FileServiceImpl.java
@@ -49,7 +49,6 @@ public class FileServiceImpl implements FileService {
 
     @Override
     public List<Path> getAllFiles(Path path) throws IOException {
-        //checkBaseFolderSecurity(path);
         try (var stream = Files.walk(path)) {
             return stream.filter(Files::isRegularFile).collect(Collectors.toList());
         }
@@ -57,7 +56,6 @@ public class FileServiceImpl implements FileService {
 
     @Override
     public List<Path> getAllFilesAndDirectories(Path path) throws IOException {
-        //checkBaseFolderSecurity(path);
         try (var stream = Files.walk(path)) {
             return stream.collect(Collectors.toList());
         }
@@ -65,7 +63,6 @@ public class FileServiceImpl implements FileService {
 
     @Override
     public byte[] readFileContents(Path path) throws IOException {
-        //checkBaseFolderSecurity(path);
         return Files.readAllBytes(path);
     }
 
@@ -81,7 +78,6 @@ public class FileServiceImpl implements FileService {
 
     @Override
     public CharBuffer readFileContents(Path path, Charset charset) throws IOException {
-        //checkBaseFolderSecurity(path);
         var contents = readFileContents(path);
         return charset.newDecoder().decode(ByteBuffer.wrap(contents));
     }
@@ -118,19 +114,10 @@ public class FileServiceImpl implements FileService {
 
     @Override
     public Optional<Path> getFirstDirectory(Path path) throws IOException {
-//        checkBaseFolderSecurity(path);
         try (var s = Files.walk(path)) {
             return s.filter(this::isDirectory).skip(1).findFirst();
         }
     }
-
-/*    @Override
-    public void checkBaseFolderSecurity(Path path) throws RuntimeException {
-        Path toCheckPath = path.normalize().toAbsolutePath();
-        if (!toCheckPath.startsWith(this.baseFolder)) {
-            throw new IllegalArgumentException(String.format("InsecurePath %s", toCheckPath));
-        }
-    }*/
 
     @Override
     public Path getSecurePath(Path path) throws RuntimeException {

--- a/src/main/java/nl/knaw/dans/validatedansbag/core/service/FileServiceImpl.java
+++ b/src/main/java/nl/knaw/dans/validatedansbag/core/service/FileServiceImpl.java
@@ -49,7 +49,7 @@ public class FileServiceImpl implements FileService {
 
     @Override
     public List<Path> getAllFiles(Path path) throws IOException {
-        checkBaseFolderSecurity(path);
+        //checkBaseFolderSecurity(path);
         try (var stream = Files.walk(path)) {
             return stream.filter(Files::isRegularFile).collect(Collectors.toList());
         }
@@ -57,7 +57,7 @@ public class FileServiceImpl implements FileService {
 
     @Override
     public List<Path> getAllFilesAndDirectories(Path path) throws IOException {
-        checkBaseFolderSecurity(path);
+        //checkBaseFolderSecurity(path);
         try (var stream = Files.walk(path)) {
             return stream.collect(Collectors.toList());
         }
@@ -65,7 +65,7 @@ public class FileServiceImpl implements FileService {
 
     @Override
     public byte[] readFileContents(Path path) throws IOException {
-        checkBaseFolderSecurity(path);
+        //checkBaseFolderSecurity(path);
         return Files.readAllBytes(path);
     }
 
@@ -81,7 +81,7 @@ public class FileServiceImpl implements FileService {
 
     @Override
     public CharBuffer readFileContents(Path path, Charset charset) throws IOException {
-        checkBaseFolderSecurity(path);
+        //checkBaseFolderSecurity(path);
         var contents = readFileContents(path);
         return charset.newDecoder().decode(ByteBuffer.wrap(contents));
     }
@@ -117,18 +117,27 @@ public class FileServiceImpl implements FileService {
 
     @Override
     public Optional<Path> getFirstDirectory(Path path) throws IOException {
-        checkBaseFolderSecurity(path);
+//        checkBaseFolderSecurity(path);
         try (var s = Files.walk(path)) {
             return s.filter(this::isDirectory).skip(1).findFirst();
         }
     }
 
-    @Override
+/*    @Override
     public void checkBaseFolderSecurity(Path path) throws RuntimeException {
         Path toCheckPath = path.normalize().toAbsolutePath();
         if (!toCheckPath.startsWith(this.baseFolder)) {
             throw new IllegalArgumentException(String.format("InsecurePath %s", toCheckPath));
         }
+    }*/
+
+    @Override
+    public Path getSecurePath(Path path) throws RuntimeException {
+        Path normalizedPath = path.normalize().toAbsolutePath();
+        if (!normalizedPath.startsWith(this.baseFolder)) {
+            throw new IllegalArgumentException(String.format("Insecure Path %s", normalizedPath));
+        }
+        return normalizedPath;
     }
 
     void writeStreamToFile(InputStream inputStream, Path target) throws IOException {

--- a/src/main/java/nl/knaw/dans/validatedansbag/core/service/RuleEngineServiceImpl.java
+++ b/src/main/java/nl/knaw/dans/validatedansbag/core/service/RuleEngineServiceImpl.java
@@ -46,7 +46,7 @@ public class RuleEngineServiceImpl implements RuleEngineService {
     public List<RuleValidationResult> validateBag(Path path, DepositType depositType) throws Exception {
         log.info("Validating bag on path '{}', deposit type is {}", path, depositType);
 
-        fileService.checkBaseFolderSecurity(path);
+        //fileService.checkBaseFolderSecurity(path);
 
         if (!fileService.isReadable(path)) {
             log.warn("Path {} could not not be found or is not readable", path);

--- a/src/main/java/nl/knaw/dans/validatedansbag/core/service/RuleEngineServiceImpl.java
+++ b/src/main/java/nl/knaw/dans/validatedansbag/core/service/RuleEngineServiceImpl.java
@@ -46,8 +46,6 @@ public class RuleEngineServiceImpl implements RuleEngineService {
     public List<RuleValidationResult> validateBag(Path path, DepositType depositType) throws Exception {
         log.info("Validating bag on path '{}', deposit type is {}", path, depositType);
 
-        //fileService.checkBaseFolderSecurity(path);
-
         if (!fileService.isReadable(path)) {
             log.warn("Path {} could not not be found or is not readable", path);
             throw new BagNotFoundException(String.format("Bag on path '%s' could not be found or read", path));

--- a/src/main/java/nl/knaw/dans/validatedansbag/resources/ValidateResource.java
+++ b/src/main/java/nl/knaw/dans/validatedansbag/resources/ValidateResource.java
@@ -74,7 +74,7 @@ public class ValidateResource {
             }
             else {
                 var locationPath = java.nio.file.Path.of(location);
-                fileService.checkBaseFolderSecurity(locationPath);
+//                fileService.checkBaseFolderSecurity(locationPath);
                 validateResult = validatePath(locationPath, depositType);
             }
 

--- a/src/main/java/nl/knaw/dans/validatedansbag/resources/ValidateResource.java
+++ b/src/main/java/nl/knaw/dans/validatedansbag/resources/ValidateResource.java
@@ -74,8 +74,9 @@ public class ValidateResource {
             }
             else {
                 var locationPath = java.nio.file.Path.of(location);
+                var securePath = fileService.getSecurePath(locationPath);
 //                fileService.checkBaseFolderSecurity(locationPath);
-                validateResult = validatePath(locationPath, depositType);
+                validateResult = validatePath(securePath, depositType);
             }
 
             // this information is lost during the validation, so set it again here

--- a/src/main/java/nl/knaw/dans/validatedansbag/resources/ValidateResource.java
+++ b/src/main/java/nl/knaw/dans/validatedansbag/resources/ValidateResource.java
@@ -75,7 +75,6 @@ public class ValidateResource {
             else {
                 var locationPath = java.nio.file.Path.of(location);
                 var securePath = fileService.getSecurePath(locationPath);
-//                fileService.checkBaseFolderSecurity(locationPath);
                 validateResult = validatePath(securePath, depositType);
             }
 

--- a/src/test/java/nl/knaw/dans/validatedansbag/core/service/OriginalFilepathsServiceImplTest.java
+++ b/src/test/java/nl/knaw/dans/validatedansbag/core/service/OriginalFilepathsServiceImplTest.java
@@ -97,6 +97,8 @@ class OriginalFilepathsServiceImplTest {
         Path basePath = Path.of(OriginalFilepathsServiceImplTest.class.getClassLoader().getName()).toAbsolutePath();
         var fileServiceImp = new FileServiceImpl(basePath);
         Path testPath = Path.of("/it/is/here");
-        assertThrows(IllegalArgumentException.class, () -> fileServiceImp.getSecurePath(testPath));
+        assertThatThrownBy( () -> fileServiceImp.getSecurePath(testPath))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("XXX");
     }
 }

--- a/src/test/java/nl/knaw/dans/validatedansbag/core/service/OriginalFilepathsServiceImplTest.java
+++ b/src/test/java/nl/knaw/dans/validatedansbag/core/service/OriginalFilepathsServiceImplTest.java
@@ -26,7 +26,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class OriginalFilepathsServiceImplTest {
     final FileService fileService = Mockito.mock(FileService.class);
@@ -99,6 +99,6 @@ class OriginalFilepathsServiceImplTest {
         Path testPath = Path.of("/it/is/here");
         assertThatThrownBy( () -> fileServiceImp.getSecurePath(testPath))
                     .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("XXX");
+                    .hasMessage(String.format("Insecure Path %s", testPath.normalize().toAbsolutePath()));
     }
 }

--- a/src/test/java/nl/knaw/dans/validatedansbag/core/service/OriginalFilepathsServiceImplTest.java
+++ b/src/test/java/nl/knaw/dans/validatedansbag/core/service/OriginalFilepathsServiceImplTest.java
@@ -93,7 +93,7 @@ class OriginalFilepathsServiceImplTest {
     }
 
     @Test
-     void getSecurePath_should_throws_IllegalArgumentException(){
+     void getSecurePath_should_throw_IllegalArgumentException(){
         Path basePath = Path.of(OriginalFilepathsServiceImplTest.class.getClassLoader().getName()).toAbsolutePath();
         var fileServiceImp = new FileServiceImpl(basePath);
         Path testPath = Path.of("/it/is/here");

--- a/src/test/java/nl/knaw/dans/validatedansbag/core/service/OriginalFilepathsServiceImplTest.java
+++ b/src/test/java/nl/knaw/dans/validatedansbag/core/service/OriginalFilepathsServiceImplTest.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class OriginalFilepathsServiceImplTest {
     final FileService fileService = Mockito.mock(FileService.class);
@@ -37,9 +38,11 @@ class OriginalFilepathsServiceImplTest {
 
     @Test
     void getMapping_should_map_files_to_original_paths_based_on_txt() throws Exception {
-        var contents = "data/12.txt data/leeg.txt\n"
-            + "data/13.txt data/sub/leeg2.txt\n"
-            + "data/14.txt data/sub/sub/vacio.txt\n";
+        var contents = """
+                data/12.txt data/leeg.txt
+                data/13.txt data/sub/leeg2.txt
+                data/14.txt data/sub/sub/vacio.txt
+                """;
 
         Mockito.when(fileService.readFileContents(Mockito.eq(Path.of("bagdir/original-filepaths.txt"))))
             .thenReturn(contents.getBytes(StandardCharsets.UTF_8));
@@ -58,9 +61,11 @@ class OriginalFilepathsServiceImplTest {
 
     @Test
     void getMapping_should_ignore_row_with_1_item() throws Exception {
-        var contents = "data/12.txt data/leeg.txt\n"
-            + "data/13.txt data/sub/leeg2.txt\n"
-            + "singleitem\n";
+        var contents = """
+                data/12.txt data/leeg.txt
+                data/13.txt data/sub/leeg2.txt
+                singleitem
+                """;
 
         Mockito.when(fileService.readFileContents(Mockito.eq(Path.of("bagdir/original-filepaths.txt"))))
             .thenReturn(contents.getBytes(StandardCharsets.UTF_8));
@@ -85,5 +90,13 @@ class OriginalFilepathsServiceImplTest {
         var result = service.getMapping(Path.of("bagdir"));
 
         assertEquals(0, result.size());
+    }
+
+    @Test
+     void getSecurePath_should_throws_IllegalArgumentException(){
+        Path basePath = Path.of(OriginalFilepathsServiceImplTest.class.getClassLoader().getName()).toAbsolutePath();
+        var fileServiceImp = new FileServiceImpl(basePath);
+        Path testPath = Path.of("/it/is/here");
+        assertThrows(IllegalArgumentException.class, () -> fileServiceImp.getSecurePath(testPath));
     }
 }

--- a/src/test/java/nl/knaw/dans/validatedansbag/resources/ValidateResourceTest.java
+++ b/src/test/java/nl/knaw/dans/validatedansbag/resources/ValidateResourceTest.java
@@ -65,7 +65,8 @@ class ValidateResourceTest {
         var multipart = new FormDataMultiPart()
             .field("command", data, MediaType.APPLICATION_JSON_TYPE);
 
-        Mockito.doNothing().when(fileService).checkBaseFolderSecurity(Path.of("it/is/here"));
+        //Mockito.doNothing().when(fileService).checkBaseFolderSecurity(Path.of("it/is/here"));
+        Mockito.doReturn(Path.of("it/is/here")).when(fileService).getSecurePath(Path.of("it/is/here"));
 
         var response = EXT.target("/validate")
             .register(MultiPartFeature.class)

--- a/src/test/java/nl/knaw/dans/validatedansbag/resources/ValidateResourceTest.java
+++ b/src/test/java/nl/knaw/dans/validatedansbag/resources/ValidateResourceTest.java
@@ -65,8 +65,8 @@ class ValidateResourceTest {
         var multipart = new FormDataMultiPart()
             .field("command", data, MediaType.APPLICATION_JSON_TYPE);
 
-        //Mockito.doNothing().when(fileService).checkBaseFolderSecurity(Path.of("it/is/here"));
-        Mockito.doReturn(Path.of("it/is/here")).when(fileService).getSecurePath(Path.of("it/is/here"));
+        Path testPath = Path.of("it/is/here");
+        Mockito.doReturn(testPath).when(fileService).getSecurePath(testPath);
 
         var response = EXT.target("/validate")
             .register(MultiPartFeature.class)


### PR DESCRIPTION
Fixes DD-1458 Fix Uncontrolled data used in path expression

# Description of changes
  -  sub-folders folders to unzip, zipped files should be a sub-folder of the working folder of this service.
  - Unit-tests: base-folder is in general: `/home/project-dir/target/test-cases`
  - Added a new unit-test function`getSecurePath_should_throws_IllegalArgumentException()`

# How to test
  - Starting vagrant
    - `start-preprovisioned-box.py -s dev_archaeology`
    - `deploy.py -m dd-validate-dans-bag dev_archaeology`
    - or to follow the deposits: `deploy.py  -m dd-validate-dans-bag -m dd-manage-deposit dev_archaeology`
  
  - Deposit vaild/invalid datasets using
    - cd to local folder: `~/git/dans-core-systems/modules/dd-dans-sword2-examples` 
    - run examples: 
      - `./run-simple-deposit.sh https://dev.sword2.archaeology.datastations.nl/collection/1 user001 user001 src/main/resources/example-bags/valid/audiences`
      - `./run-validation.sh https://dev.sword2.archaeology.datastations.nl/validate-dans-bag src/main/resources/example-bags/valid/audiences-sha256`
      - `./run-validation.sh https://dev.sword2.archaeology.datastations.nl/validate-dans-bag src/main/resources/example-bags/invalid/invalid-license`
      - `./run-continued-deposit.sh https://dev.sword2.archaeology.datastations.nl/collection/1 user001 user001 200000 src/main/resources/example-bags/valid/audiences-sha256`
  
  - Looking at the results:
    - Reports:
      - in the terminal: `curl 'accept: text/csv' http://dev.sword2.archaeology.datastations.nl:20355/report`  
      - in the firefox browser: `http://dev.sword2.archaeology.datastations.nl:20355/report

# Related PRs

(Add links)

*

# Notify

@DANS-KNAW/core-systems
